### PR TITLE
Add CI workflow to run unit tests

### DIFF
--- a/.github/workflows/unit-tests.yml
+++ b/.github/workflows/unit-tests.yml
@@ -1,0 +1,55 @@
+name: Unit Tests
+
+on:
+  pull_request:
+    # Only run workflow if a file in these paths is modified
+    paths:
+      - '.github/workflows/unit-tests.yml'
+      - 'extras/test/**'
+      - 'src/**'
+
+  push:
+    paths:
+      - '.github/workflows/unit-tests.yml'
+      - 'extras/test/**'
+      - 'src/**'
+
+jobs:
+  test:
+    name: Run unit tests
+    runs-on: ubuntu-latest
+
+    env:
+      BUILD_PATH: ${{ github.workspace }}/extras/test/build
+
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@v2
+
+      - name: Install valgrind
+        run: sudo apt-get --assume-yes install valgrind
+
+      - name: Run unit tests
+        run: |
+          mkdir "$BUILD_PATH"
+          cd "$BUILD_PATH"
+          cmake ..
+          make
+          # Run tests and check for memory leaks
+          valgrind --leak-check=yes --error-exitcode=1 bin/testNmeaParser
+
+      - name: Install lcov
+        run: sudo apt-get --assume-yes install lcov
+
+      - name: Report code coverage
+        run: |
+          cd "$BUILD_PATH"
+          lcov --directory . --capture --output-file coverage.info
+          lcov --quiet --remove coverage.info '/usr/*' '*/extras/test/*' '*/src/lib/*' --output-file coverage.info
+          lcov --list coverage.info
+
+      - name: Upload coverage report to Codecov
+        uses: codecov/codecov-action@v1
+        with:
+          file: ${{ env.BUILD_PATH }}/coverage.info
+          fail_ci_if_error: true

--- a/README.md
+++ b/README.md
@@ -1,3 +1,5 @@
 `107-Arduino-NMEA`
 ==================
 Arduino library for interfacing with the PA1010D GPS module (MTK3333 chipset) and interpreting its NMEA messages.
+
+[![Unit Tests Status](https://github.com/107-systems/107-Arduino-NMEA/workflows/Unit%20Tests/badge.svg)](https://github.com/107-systems/107-Arduino-NMEA/actions?workflow=Unit+Tests)[![codecov](https://codecov.io/gh/107-systems/107-Arduino-NMEA/branch/master/graph/badge.svg)](https://codecov.io/gh/107-systems/107-Arduino-NMEA)


### PR DESCRIPTION
On every push and pull request, GitHub Actions will:
- Run unit tests
- Use valgrind to check for memory leaks
- Print code coverage report to workflow log
- Upload coverage data to codecov.io

Codecov will comment a coverage report to pull requests and fail the CI build if the coverage level drops below 70% (default setting, this behavior can be configured via codecov.yml).

Fixes https://github.com/107-systems/107-Arduino-NMEA/issues/2