### PR TITLE
Store last position fix timestamp as float instead of separated integers

### DIFF
--- a/extras/test/src/test_GPRMC.cpp
+++ b/extras/test/src/test_GPRMC.cpp
@@ -19,12 +19,11 @@
  * GLOBAL VARIABLES
  **************************************************************************************/
 
-static float    latitude;
-static float    longitude;
-static float    speed;
-static float    course;
-static uint32_t last_fix_utc_s;
-static uint16_t last_fix_utc_ms;
+static float latitude;
+static float longitude;
+static float speed;
+static float course;
+static float last_fix_utc_s;
 
 /**************************************************************************************
  * TEST CODE
@@ -36,7 +35,7 @@ SCENARIO("Extracting latitude/longiture from valid GPRMC message", "[GPRMC-01]")
   {
     std::string const GPRMC = "$GPRMC,062101.714,A,5001.869,N,01912.114,E,955535.7,116.2,290520,000.0,W*45\r\n";
 
-    REQUIRE(nmea::GPRMC::parse(GPRMC.c_str(), last_fix_utc_s, last_fix_utc_ms, latitude, longitude, speed, course) == true);
+    REQUIRE(nmea::GPRMC::parse(GPRMC.c_str(), last_fix_utc_s, latitude, longitude, speed, course) == true);
     REQUIRE(latitude  == Approx(50.03114442));
     REQUIRE(longitude == Approx(19.20189679));
   }
@@ -45,7 +44,7 @@ SCENARIO("Extracting latitude/longiture from valid GPRMC message", "[GPRMC-01]")
   {
     std::string const GPRMC = "$GPRMC,122311.239,A,4056.748,N,11212.614,W,,,290620,000.0,W*63\r\n";
 
-    REQUIRE(nmea::GPRMC::parse(GPRMC.c_str(), last_fix_utc_s, last_fix_utc_ms, latitude, longitude, speed, course) == true);
+    REQUIRE(nmea::GPRMC::parse(GPRMC.c_str(), last_fix_utc_s, latitude, longitude, speed, course) == true);
     REQUIRE(latitude  == Approx(40.9458060446613));
     REQUIRE(longitude == Approx(-112.210235595703));
   }
@@ -54,7 +53,7 @@ SCENARIO("Extracting latitude/longiture from valid GPRMC message", "[GPRMC-01]")
   {
     std::string const GPRMC = "$GPRMC,122311.239,A,2727.069,S,05859.190,W,,,290620,000.0,W*76\r\n";
 
-    REQUIRE(nmea::GPRMC::parse(GPRMC.c_str(), last_fix_utc_s, last_fix_utc_ms, latitude, longitude, speed, course) == true);
+    REQUIRE(nmea::GPRMC::parse(GPRMC.c_str(), last_fix_utc_s, latitude, longitude, speed, course) == true);
     REQUIRE(latitude  == Approx(-27.4511422937699));
     REQUIRE(longitude == Approx(-58.986502289772));
   }
@@ -63,7 +62,7 @@ SCENARIO("Extracting latitude/longiture from valid GPRMC message", "[GPRMC-01]")
   {
     std::string const GPRMC = "$GPRMC,122311.239,A,0610.522,S,10649.632,E,,,290620,000.0,W*6D\r\n";
 
-    REQUIRE(nmea::GPRMC::parse(GPRMC.c_str(), last_fix_utc_s, last_fix_utc_ms, latitude, longitude, speed, course) == true);
+    REQUIRE(nmea::GPRMC::parse(GPRMC.c_str(), last_fix_utc_s, latitude, longitude, speed, course) == true);
     REQUIRE(latitude  == Approx(-6.17536097471491));
     REQUIRE(longitude == Approx(106.827192306519));
   }
@@ -73,7 +72,7 @@ TEST_CASE("Extracting speed over ground from valid GPRMC message", "[GPRMC-02]")
 {
   std::string const GPRMC = ("$GPRMC,052856.105,A,5230.874,N,01321.056,E,085.7,206.4,080720,000.0,W*78\r\n");
 
-  REQUIRE(nmea::GPRMC::parse(GPRMC.c_str(), last_fix_utc_s, last_fix_utc_ms, latitude, longitude, speed, course) == true);
+  REQUIRE(nmea::GPRMC::parse(GPRMC.c_str(), last_fix_utc_s, latitude, longitude, speed, course) == true);
   /* 85.7 kts ~= 44.088 m/s */
   REQUIRE(speed == Approx(44.088f));
 }
@@ -82,7 +81,7 @@ TEST_CASE("Extracting track angle from valid GPRMC message", "[GPRMC-03]")
 {
   std::string const GPRMC = ("$GPRMC,052856.105,A,5230.874,N,01321.056,E,085.7,206.4,080720,000.0,W*78\r\n");
 
-  REQUIRE(nmea::GPRMC::parse(GPRMC.c_str(), last_fix_utc_s, last_fix_utc_ms, latitude, longitude, speed, course) == true);
+  REQUIRE(nmea::GPRMC::parse(GPRMC.c_str(), last_fix_utc_s, latitude, longitude, speed, course) == true);
   REQUIRE(course == Approx(206.4f));
 }
 
@@ -90,23 +89,21 @@ TEST_CASE("Extracting position time from valid GPRMC message", "[GPRMC-04]")
 {
   std::string const GPRMC = ("$GPRMC,052856.105,A,5230.874,N,01321.056,E,085.7,206.4,080720,000.0,W*78\r\n");
 
-  REQUIRE(nmea::GPRMC::parse(GPRMC.c_str(), last_fix_utc_s, last_fix_utc_ms, latitude, longitude, speed, course) == true);
+  REQUIRE(nmea::GPRMC::parse(GPRMC.c_str(), last_fix_utc_s, latitude, longitude, speed, course) == true);
   /* 052856.105 -> 05:28:56.105 -> */
-  REQUIRE(last_fix_utc_s  == 5*3600 + 28*60 + 56);
-  REQUIRE(last_fix_utc_ms == 105);
+  REQUIRE(last_fix_utc_s  == Approx(5*3600 + 28*60 + 56 + 0.105f));
 }
 
 TEST_CASE("Extracted status indicates void ('V') position data", "[GPRMC-05]")
 {
   std::string const GPRMC = ("$GPRMC,052856.105,V,5230.874,N,01321.056,E,085.7,206.4,080720,000.0,W*78\r\n");
 
-  latitude = 1.0f; longitude = 2.0f; speed = 3.0f; course = 4.0f; last_fix_utc_s = 0; last_fix_utc_ms = 0;
+  latitude = 1.0f; longitude = 2.0f; speed = 3.0f; course = 4.0f; last_fix_utc_s = 0;
 
-  REQUIRE(nmea::GPRMC::parse(GPRMC.c_str(), last_fix_utc_s, last_fix_utc_ms, latitude, longitude, speed, course) == true);
+  REQUIRE(nmea::GPRMC::parse(GPRMC.c_str(), last_fix_utc_s, latitude, longitude, speed, course) == true);
   REQUIRE(latitude        == 1.0f);
   REQUIRE(longitude       == 2.0f);
   REQUIRE(speed           == 3.0f);
   REQUIRE(course          == 4.0f);
-  REQUIRE(last_fix_utc_s  == 5*3600 + 28*60 + 56);
-  REQUIRE(last_fix_utc_ms == 105);
+  REQUIRE(last_fix_utc_s  == Approx(5*3600 + 28*60 + 56 + 0.105f));
 }

--- a/extras/test/src/test_Parser.cpp
+++ b/extras/test/src/test_Parser.cpp
@@ -39,10 +39,9 @@ TEST_CASE("No NMEA message received", "[Parser-01]")
 
   REQUIRE     (parser.latitude()  == Approx(20.9860468));
   REQUIRE     (parser.longitude() == Approx(52.2637009));
-  REQUIRE_THAT(parser.speed(),  Catch::Matchers::WithinULP(0.0f, 10));
-  REQUIRE_THAT(parser.course(), Catch::Matchers::WithinULP(0.0f, 10));
-  REQUIRE     (parser.last_fix_utc_s()  == 0);
-  REQUIRE     (parser.last_fix_utc_ms() == 0);
+  REQUIRE_THAT(parser.speed(),          Catch::Matchers::WithinULP(0.0f, 10));
+  REQUIRE_THAT(parser.course(),         Catch::Matchers::WithinULP(0.0f, 10));
+  REQUIRE_THAT(parser.last_fix_utc_s(), Catch::Matchers::WithinULP(0.0f, 10));
 }
 
 TEST_CASE("Decoding starts mid-message", "[Parser-02]")
@@ -57,8 +56,7 @@ TEST_CASE("Decoding starts mid-message", "[Parser-02]")
   REQUIRE(parser.longitude()       == Approx(13.349300));
   REQUIRE(parser.speed()           == Approx(39.6122));
   REQUIRE(parser.course()          == Approx(23.5));
-  REQUIRE(parser.last_fix_utc_s()  == 5*3600 + 28*60 + 52);
-  REQUIRE(parser.last_fix_utc_ms() == 105);
+  REQUIRE(parser.last_fix_utc_s()  == Approx(5*3600 + 28*60 + 52 + 0.105f));
 }
 
 TEST_CASE("NMEA message with data corruption (checksum mismatch) received", "[Parser-03]")

--- a/src/GPRMC.cpp
+++ b/src/GPRMC.cpp
@@ -34,7 +34,7 @@ bool GPRMC::isGPRMC(char const * nmea)
   return (strncmp(nmea, "$GPRMC", 6) == 0);
 }
 
-bool GPRMC::parse(char const * gprmc, uint32_t & last_fix_utc_s, uint16_t & last_fix_utc_ms, float & latitude, float & longitude, float & speed, float & course)
+bool GPRMC::parse(char const * gprmc, float & last_fix_utc_s, float & latitude, float & longitude, float & speed, float & course)
 {
   ParserState state = ParserState::MessadeId;
   
@@ -46,18 +46,18 @@ bool GPRMC::parse(char const * gprmc, uint32_t & last_fix_utc_s, uint16_t & last
 
     switch(state)
     {
-    case ParserState::MessadeId:         next_state = handle_MessadeId        (token);                                  break;
-    case ParserState::UTCPositionFix:    next_state = handle_UTCPositionFix   (token, last_fix_utc_s, last_fix_utc_ms); break;
-    case ParserState::Status:            next_state = handle_Status           (token);                                  break;
-    case ParserState::LatitudeVal:       next_state = handle_LatitudeVal      (token, latitude);                        break;
-    case ParserState::LatitudeNS:        next_state = handle_LatitudeNS       (token, latitude);                        break;
-    case ParserState::LongitudeVal:      next_state = handle_LongitudeVal     (token, longitude);                       break;
-    case ParserState::LongitudeEW:       next_state = handle_LongitudeEW      (token, longitude);                       break;
-    case ParserState::SpeedOverGround:   next_state = handle_SpeedOverGround  (token, speed);                           break;
-    case ParserState::TrackAngle:        next_state = handle_TrackAngle       (token, course);                          break;
-    case ParserState::Checksum:          next_state = handle_Checksum         (token);                                  break;
-    case ParserState::Done:              return true;                                                                   break;
-    case ParserState::Error:             return false;                                                                  break;
+    case ParserState::MessadeId:         next_state = handle_MessadeId        (token);                 break;
+    case ParserState::UTCPositionFix:    next_state = handle_UTCPositionFix   (token, last_fix_utc_s); break;
+    case ParserState::Status:            next_state = handle_Status           (token);                 break;
+    case ParserState::LatitudeVal:       next_state = handle_LatitudeVal      (token, latitude);       break;
+    case ParserState::LatitudeNS:        next_state = handle_LatitudeNS       (token, latitude);       break;
+    case ParserState::LongitudeVal:      next_state = handle_LongitudeVal     (token, longitude);      break;
+    case ParserState::LongitudeEW:       next_state = handle_LongitudeEW      (token, longitude);      break;
+    case ParserState::SpeedOverGround:   next_state = handle_SpeedOverGround  (token, speed);          break;
+    case ParserState::TrackAngle:        next_state = handle_TrackAngle       (token, course);         break;
+    case ParserState::Checksum:          next_state = handle_Checksum         (token);                 break;
+    case ParserState::Done:              return true;                                                  break;
+    case ParserState::Error:             return false;                                                 break;
     };
 
     state = next_state;
@@ -78,7 +78,7 @@ GPRMC::ParserState GPRMC::handle_MessadeId(char const * token)
     return ParserState::Error;
 }
 
-GPRMC::ParserState GPRMC::handle_UTCPositionFix(char const * token, uint32_t & last_fix_utc_s, uint16_t & last_fix_utc_ms)
+GPRMC::ParserState GPRMC::handle_UTCPositionFix(char const * token, float & last_fix_utc_s)
 {
   char const hour_str       [] = {token[0], token[1], '\0'};
   char const minute_str     [] = {token[2], token[3], '\0'};
@@ -88,7 +88,7 @@ GPRMC::ParserState GPRMC::handle_UTCPositionFix(char const * token, uint32_t & l
   last_fix_utc_s  = atoi(second_str);
   last_fix_utc_s += atoi(minute_str) * 60;
   last_fix_utc_s += atoi(hour_str) * 3600;
-  last_fix_utc_ms = atoi(millisecond_str);
+  last_fix_utc_s += static_cast<float>(atoi(millisecond_str)) / 1000.f;
 
   return ParserState::Status;
 }

--- a/src/GPRMC.h
+++ b/src/GPRMC.h
@@ -31,8 +31,7 @@ public:
   static bool isGPRMC(char const * nmea);
 
   static bool parse(char const * gprmc, 
-                    uint32_t & last_fix_utc_s,
-                    uint16_t & last_fix_utc_ms,
+                    float & last_fix_utc_s,
                     float & latitude,
                     float & longitude,
                     float & speed,
@@ -60,7 +59,7 @@ private:
   };
 
   static ParserState handle_MessadeId        (char const * token);
-  static ParserState handle_UTCPositionFix   (char const * token, uint32_t & last_fix_utc_s, uint16_t & last_fix_utc_ms);
+  static ParserState handle_UTCPositionFix   (char const * token, float & last_fix_utc_s);
   static ParserState handle_Status           (char const * token);
   static ParserState handle_LatitudeVal      (char const * token, float & latitude);
   static ParserState handle_LatitudeNS       (char const * token, float & latitude);

--- a/src/Parser.cpp
+++ b/src/Parser.cpp
@@ -30,7 +30,7 @@ Parser::Parser()
 : _error{Error::None}
 , _parser_state{ParserState::Synching}
 , _parser_buf{{0}, 0}
-, _position{20.9860468, 52.2637009, 0.0, 0.0, 0, 0}
+, _position{20.9860468, 52.2637009, 0.0, 0.0, 0.0}
 {
 
 }
@@ -123,7 +123,7 @@ void Parser::terminateParserBuffer()
 
 void Parser::parseGPRMC()
 {
-  if (!GPRMC::parse(_parser_buf.buf, _position.last_fix_utc_s, _position.last_fix_utc_ms, _position.latitude, _position.longitude, _position.speed, _position.course))
+  if (!GPRMC::parse(_parser_buf.buf, _position.last_fix_utc_s, _position.latitude, _position.longitude, _position.speed, _position.course))
     _error = Error::RMC;
 }
 

--- a/src/Parser.h
+++ b/src/Parser.h
@@ -35,12 +35,11 @@ public:
   void encode(char const c);
 
 
-  inline float    latitude       () const { return _position.latitude; }
-  inline float    longitude      () const { return _position.longitude; }
-  inline float    speed          () const { return _position.speed; }
-  inline float    course         () const { return _position.course; }
-  inline uint32_t last_fix_utc_s () const { return _position.last_fix_utc_s; }
-  inline uint16_t last_fix_utc_ms() const { return _position.last_fix_utc_ms; }
+  inline float latitude       () const { return _position.latitude; }
+  inline float longitude      () const { return _position.longitude; }
+  inline float speed          () const { return _position.speed; }
+  inline float course         () const { return _position.course; }
+  inline float last_fix_utc_s () const { return _position.last_fix_utc_s; }
 
 
   enum class Error { None, Checksum, RMC };
@@ -61,12 +60,11 @@ private:
 
   typedef struct
   {
-    float    latitude;
-    float    longitude;
-    float    speed;
-    float    course;
-    uint32_t last_fix_utc_s;
-    uint16_t last_fix_utc_ms;
+    float latitude;
+    float longitude;
+    float speed;
+    float course;
+    float last_fix_utc_s;
   } PositionData;
 
   enum class ParserState


### PR DESCRIPTION
Instead of storing seconds separate from milliseconds better group them within one float, with a max value of 86400 seconds and a millisecond precision of 1 ms we don't need to worry about loosing precision on the float type